### PR TITLE
Remove dead link, correct and comment other link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ Alternatives
 There are two other questionnaire-type applications that we stumbled upon, but
 they both didn't quite scratch our itch, but they may scratch yours.
 
-Django Questionnaire - [http://djangoquest.aperte-it.com/]()
-
-Django Survey - [http://code.google.com/p/django-survey/]()
+Django Survey (slightly outdated, last change 2009) - [django-survey](http://code.google.com/p/django-survey/)
 
 History
 -------


### PR DESCRIPTION
The one alternative cannot be found on the link, the trac system is down, and the website of the main domain is redirected to another company, which doesn't mention the questionnaire. Also correct the link to the other alternative which was not correct in markup, and add comment that the software hasn't had a change since 2009.
