### PR TITLE
Replaces mimetype= with content_type= in calls to HttpResponse, updated for Django 1.6+

### DIFF
--- a/questionnaire/emails.py
+++ b/questionnaire/emails.py
@@ -156,5 +156,5 @@ def send_emails(request=None, qname=None):
                 outlog.append("Exception: [%s] %s: %s" % (r.runid, r.subject.surname, str(e)))
     if request:
         return HttpResponse("Sent Questionnaire Emails:\n  "
-            +"\n  ".join(outlog), mimetype="text/plain")
+            +"\n  ".join(outlog), content_type="text/plain")
     return "\n".join(outlog)

--- a/questionnaire/views.py
+++ b/questionnaire/views.py
@@ -218,7 +218,7 @@ def get_async_progress(request, *args, **kwargs):
 
     cache.set('progress' + runinfo.random, response['progress'])
     response = HttpResponse(json.dumps(response),
-               mimetype='application/javascript');
+               content_type='application/javascript');
     response["Cache-Control"] = "no-cache"
     return response
 
@@ -765,7 +765,7 @@ def export_csv(request, qid): # questionnaire_id
             a if a else '--' for a in answer_row]
         writer.writerow(row)
 
-    response = HttpResponse(FileWrapper(fd), mimetype="text/csv")
+    response = HttpResponse(FileWrapper(fd), content_type="text/csv")
     response['Content-Length'] = fd.tell()
     response['Content-Disposition'] = 'attachment; filename="export-%s.csv"' % qid
     fd.seek(0)


### PR DESCRIPTION
The mimetype parameter was renamed to content_type between Django 1.4 and 1.5, and Django versions prior to 1.6 are deprecated (iinm)
