### PR TITLE
Perform natural sort on question number.

### DIFF
--- a/questionnaire/models.py
+++ b/questionnaire/models.py
@@ -102,7 +102,10 @@ class QuestionSet(models.Model):
 
     def questions(self):
         if not hasattr(self, "__qcache"):
-            self.__qcache = list(Question.objects.filter(questionset=self.id).extra(select={'numericnumber': 'CAST(number AS UNSIGNED)'}).order_by('numericnumber', 'number'))
+            def numeric_number(val):
+                matches = re.findall(r'^\d+', val)
+                return int(matches[0]) if matches else 0
+            self.__qcache = sorted(Question.objects.filter(questionset=self.id), key=lambda q: (numeric_number(q.number), q.number))
         return self.__qcache
 
     def next(self):


### PR DESCRIPTION
Currently the question with the number "10" comes before the question with the number "1" because the sort is done on string characters, not on natural numbers. This patch casts the "number" fields to an integer and sorts by the casted number first, and by the string number later (so that the order will be "1", "1a", "2", …, "10", "10a", "10b")

CAST is ANSI SQL and I tested this implementation on both SQLite and MySQL.
