### PR TITLE
Adding support for passing subject id into questionnaire run creation

### DIFF
--- a/questionnaire/views.py
+++ b/questionnaire/views.py
@@ -1019,11 +1019,8 @@ def generate_run(request, questionnaire_id, subject_id=None):
     qs = qu.questionsets()[0]
 
     if subject_id is not None:
-        try:
-            su = Subject.objects.get(id=subject_id)
-        except Subject.DoesNotExist:
-            su = None
-            
+        su = get_object_or_404(Subject, pk=subject_id)
+
     if not su:
         su = Subject.objects.filter(givenname='Anonymous', surname='User')[0:1]
         if su:


### PR DESCRIPTION
If the subject is missing or does not exist, the standard Anonymous subject will be used.
